### PR TITLE
Tail attack & bugs

### DIFF
--- a/05-SceneManager/Mario.cpp
+++ b/05-SceneManager/Mario.cpp
@@ -16,6 +16,7 @@
 #include "PlayScene.h"
 
 #define MARIO_FALLING_SPEED_SLOW 0.1f // tốc độ rơi Mario, bị hãm bởi nút S vẫy đuôi
+#define MARIO_TAIL_ATTACK_TIME 250 // 250 = voi tong thoi gian animation
 
 CMario* CMario::__instance = NULL;
 int _switchSceneId = 0;
@@ -36,9 +37,9 @@ void CMario::Update(DWORD dt, vector<LPGAMEOBJECT>* coObjects)
 	}*/
 
 	//DebugOut(L"ay: %0.4f	vy: %0.4f\n", ay, vy);
-	
+
 	// Mario reach max speed 
-	
+
 	// vy += ay * dt;
 	if (!isFlying) {
 		vy += MARIO_GRAVITY * dt;
@@ -60,16 +61,16 @@ void CMario::Update(DWORD dt, vector<LPGAMEOBJECT>* coObjects)
 		state = MARIO_STATE_SIT;
 	}
 	else if (canKick == true)
-		 // reset lại canKick và hiện ani đá khi canKick=true
+		// reset lại canKick và hiện ani đá khi canKick=true
 	{
 		if (AttackTime != 0 && GetTickCount64() - AttackTime > 100)
 		{
 			canKick = false;
 			AttackTime = 0;
 		}
-		
+
 	}
-	
+
 	if (isPiping) {
 		if (GetTickCount64() - timer >= MARIO_PIPING_TIME) {
 			isPiping = false;
@@ -102,7 +103,6 @@ void CMario::Update(DWORD dt, vector<LPGAMEOBJECT>* coObjects)
 	HandleRacoonAttack(dt, coObjects);
 
 	CCollision::GetInstance()->Process(this, dt, coObjects);
-	// HandleRacoonAttack(dt, coObjects);
 }
 
 void CMario::OnNoCollision(DWORD dt)
@@ -151,7 +151,7 @@ void CMario::OnCollisionWithItem(LPCOLLISIONEVENT e) {
 	{
 		OnCollisionWithCoin(e);
 	}
-	else 
+	else
 	{
 		if (dynamic_cast<CSuperItem*>(e->obj)) {
 			CSuperItem* superItem = dynamic_cast<CSuperItem*>(e->obj);
@@ -177,13 +177,13 @@ void CMario::OnCollisionWithPipe(LPCOLLISIONEVENT e) {
 
 	// có sceneId gán vào cái cống
 	bool canTeleport = pipe->GetDestinationSceneId() != -1;
-	
+
 	if (canTeleport) {
 		float x1, y1;
 		pipe->GetPosition(x1, y1);
 
 		// mario nằm trong vùng có thể bấm S để chui cống
-		bool inRange = x > x1 && x < x1 + PIPE_BBOX_DOWN_RANGE; 
+		bool inRange = x > x1 && x < x1 + PIPE_BBOX_DOWN_RANGE;
 		if (e->ny < 0) {
 			if (inRange) {
 				if (state == MARIO_STATE_SIT) {
@@ -211,16 +211,16 @@ void CMario::OnCollisionWithKoopas(LPCOLLISIONEVENT e)
 {
 	CKoopas* koopas = dynamic_cast<CKoopas*>(e->obj);
 	if (e->nx != 0) {	// horizontal
-			// k ở dạng mai rùa thì giảm cấp
+		// k ở dạng mai rùa thì giảm cấp
 		if (koopas->isShell == false && koopas->isShell_2 == false)
 		{
 			if (untouchable == 0) {
-				if (level > MARIO_LEVEL_SMALL) 
+				if (level > MARIO_LEVEL_SMALL)
 				{
 					level--;
 					StartUntouchable();
 				}
-				else 
+				else
 					SetState(MARIO_STATE_DIE);
 			}
 		}
@@ -252,7 +252,7 @@ void CMario::OnCollisionWithKoopas(LPCOLLISIONEVENT e)
 						else
 							koopas->SetState(KOOPAS_STATE_SHELL_2_HOLD);
 					}
-					
+
 				}
 				else if (e->nx == 1)
 				{
@@ -278,7 +278,7 @@ void CMario::OnCollisionWithKoopas(LPCOLLISIONEVENT e)
 			koopas->ReviveTime = GetTickCount64();
 		}
 		else if (koopas->GetState() == KOOPAS_STATE_SHELL)
-			{
+		{
 			koopas->y -= 1;
 			if (this->x <= koopas->x)
 			{
@@ -401,7 +401,7 @@ void CMario::OnCollisionWithCoin(LPCOLLISIONEVENT e)
 	CCoin* coin = dynamic_cast<CCoin*>(e->obj);
 
 	bool c = coin->GetState() == STATE_ITEM_VISIBLE;
-	if (c) 
+	if (c)
 	{
 		e->obj->Delete();
 		coin++;
@@ -590,7 +590,7 @@ int CMario::GetAniIdBig()
 			}
 			else // vx < 0
 			{
-				
+
 				if (ax > 0)
 					aniId = ID_ANI_MARIO_BRACE_LEFT;
 				else if (abs(ax) == MARIO_ACCEL_RUN_X)
@@ -601,12 +601,12 @@ int CMario::GetAniIdBig()
 				}
 				else //if (ax == MARIO_ACCEL_WALK_X)
 					aniId = ID_ANI_MARIO_WALKING_LEFT;
-			
+
 			}
 		}
-			
+
 	}
-		
+
 
 	if (aniId == -1) aniId = ID_ANI_MARIO_IDLE_RIGHT;
 
@@ -619,7 +619,7 @@ int CMario::GetAniIdTail()
 	int aniId = -1;
 	CAnimations* animations = CAnimations::GetInstance();
 
-	
+
 	// ON AIR
 	if (!isOnPlatform) {
 		if (abs(ax) == MARIO_ACCEL_RUN_X)
@@ -643,7 +643,7 @@ int CMario::GetAniIdTail()
 
 		}
 	}
-	
+
 	else {
 		// SIT
 		if (isSitting)
@@ -689,7 +689,7 @@ int CMario::GetAniIdTail()
 	if (isPiping) { // TODO: add another level ani
 		aniId = ID_ANI_MARIO_TAIL_PIPING;
 	}
-	
+
 	if (IsAttack) {
 		if (nx > 0) aniId = ID_ANI_MARIO_TAIL_ATTACK_RIGHT;
 		else aniId = ID_ANI_MARIO_TAIL_ATTACK_LEFT;
@@ -739,7 +739,7 @@ void CMario::SetState(int state) {
 		nx = 1;
 		break;
 	}
-	
+
 	case MARIO_STATE_RUNNING_LEFT: {
 		if (isSitting) break;
 		maxVx = -MARIO_RUNNING_SPEED;
@@ -763,18 +763,18 @@ void CMario::SetState(int state) {
 		break;
 	}
 	case MARIO_STATE_JUMP: {
-			if (isSitting) break;
+		if (isSitting) break;
 		if (isOnPlatform) {
 			if (abs(this->vx) >= MARIO_RUNNING_SPEED) {
-					vy = -MARIO_JUMP_RUN_SPEED_Y;
-					// ay += 0.03f;
+				vy = -MARIO_JUMP_RUN_SPEED_Y;
+				// ay += 0.03f;
 
-					//ay = 0.0012f;
-				}
-			else {
-					vy = -MARIO_JUMP_SPEED_Y;
+				//ay = 0.0012f;
 			}
-		break;
+			else {
+				vy = -MARIO_JUMP_SPEED_Y;
+			}
+			break;
 		}
 	}
 	case MARIO_FLY_DOWN: {
@@ -782,9 +782,9 @@ void CMario::SetState(int state) {
 			if (abs(vx) >= abs(MARIO_RUNNING_SPEED)) {
 				vy = -4 * MARIO_FALLING_SPEED_SLOW;
 			}
-		else if (vy > 0) {
-			vy = MARIO_FALLING_SPEED_SLOW;
-			isFlying = true;
+			else if (vy > 0) {
+				vy = MARIO_FALLING_SPEED_SLOW;
+				isFlying = true;
 				flyTimer = GetTickCount64();
 			}
 		}
@@ -851,10 +851,10 @@ void CMario::SetState(int state) {
 		break;
 
 	case MARIO_STATE_ATTACK: {
-			IsAttack = true;
-			AttackTime = GetTickCount64();
+		IsAttack = true;
+		AttackTime = GetTickCount64();
 		break;
-		}
+	}
 	}
 
 	CGameObject::SetState(state);
@@ -904,7 +904,7 @@ void CMario::GetBoundingBox(float& left, float& top, float& right, float& bottom
 	}
 }
 
-	
+
 void CMario::SetLevel(int l)
 {
 	// Adjust position to avoid falling off platform
@@ -920,5 +920,5 @@ void CMario::SetLevel(int l)
 		_PlayScene->AddNewObject(tail);
 		render_tail = true;
 	}
-	
+
 }

--- a/05-SceneManager/Mario.cpp
+++ b/05-SceneManager/Mario.cpp
@@ -688,9 +688,8 @@ int CMario::GetAniIdTail()
 		aniId = ID_ANI_MARIO_TAIL_PIPING;
 	}
 	
-	if (IsAttack)
-	{
-		if (nx > 0)aniId = ID_ANI_MARIO_TAIL_ATTACK_RIGHT;
+	if (IsAttack) {
+		if (nx > 0) aniId = ID_ANI_MARIO_TAIL_ATTACK_RIGHT;
 		else aniId = ID_ANI_MARIO_TAIL_ATTACK_LEFT;
 	}
 	if (aniId == -1) aniId = ID_ANI_MARIO_TAIL_IDLE_RIGHT;
@@ -717,13 +716,11 @@ void CMario::Render()
 	DebugOutTitle(L"Coins: %d", coin);
 }
 
-void CMario::SetState(int state)
-{
+void CMario::SetState(int state) {
 	// DIE is the end state, cannot be changed! 
 	if (this->state == MARIO_STATE_DIE) return;
 
-	switch (state)
-	{
+	switch (state) {
 	case MARIO_STATE_RUNNING_RIGHT: {
 		if (isSitting) break;
 		maxVx = MARIO_RUNNING_SPEED;
@@ -782,23 +779,11 @@ void CMario::SetState(int state)
 		}
 		break;
 	}
-
-	//case MARIO_GIU_NUT_S: {
-	//	DebugOut(L"MARIO GIU NUT S\n");
-	//	if (vy <= -0.4f) {
-	//		ay = 0.02f;
-	//	}
-	//	else {
-	//		//ay -= 0.0002f;
-	//	}
-	//	break;
-	//}
-
-	case MARIO_STATE_RELEASE_JUMP:
+	case MARIO_STATE_RELEASE_JUMP: {
 		if (vy < 0 && isFlying == false) vy += MARIO_JUMP_SPEED_Y / 2;
 		break;
-
-	case MARIO_STATE_SIT:
+	}
+	case MARIO_STATE_SIT: {
 		if (isOnPlatform && level != MARIO_LEVEL_SMALL)
 		{
 			state = MARIO_STATE_IDLE;
@@ -807,7 +792,9 @@ void CMario::SetState(int state)
 			y += MARIO_SIT_HEIGHT_ADJUST;
 		}
 		break;
-	case MARIO_STATE_SIT_RELEASE:
+	}
+
+	case MARIO_STATE_SIT_RELEASE: {
 		if (isSitting)
 		{
 			isSitting = false;
@@ -815,6 +802,8 @@ void CMario::SetState(int state)
 			y -= MARIO_SIT_HEIGHT_ADJUST;
 		}
 		break;
+	}
+
 
 	case MARIO_STATE_IDLE:
 		if (vx != 0)
@@ -850,14 +839,11 @@ void CMario::SetState(int state)
 		ax = 0;
 		break;
 
-	case MARIO_STATE_ATTACK:
-		if (level == MARIO_LEVEL_TAIL)
-		{
+	case MARIO_STATE_ATTACK: {
 			IsAttack = true;
 			AttackTime = GetTickCount64();
-			tail->IsActive = true;
-		}
 		break;
+		}
 	}
 
 	CGameObject::SetState(state);

--- a/05-SceneManager/Mario.cpp
+++ b/05-SceneManager/Mario.cpp
@@ -883,7 +883,6 @@ void CMario::GetBoundingBox(float& left, float& top, float& right, float& bottom
 		if (isSitting)
 		{
 			left = x - MARIO_BIG_SITTING_BBOX_WIDTH / 2;
-			left += (nx < 0) ? -4 : 4;
 			top = y - MARIO_BIG_SITTING_BBOX_HEIGHT / 2;
 			right = left + MARIO_BIG_SITTING_BBOX_WIDTH;
 			bottom = top + MARIO_BIG_SITTING_BBOX_HEIGHT;
@@ -891,12 +890,9 @@ void CMario::GetBoundingBox(float& left, float& top, float& right, float& bottom
 		else
 		{
 			left = x - MARIO_BIG_BBOX_WIDTH / 2;
-			left += (nx < 0) ? -4 : 4;
 			top = y - MARIO_BIG_BBOX_HEIGHT / 2;
 			right = left + MARIO_BIG_BBOX_WIDTH;
 			bottom = top + MARIO_BIG_BBOX_HEIGHT;
-
-			//left = left + 4;
 		}
 	}
 	else
@@ -925,29 +921,4 @@ void CMario::SetLevel(int l)
 		render_tail = true;
 	}
 	
-}
-
-void CMario::RenderBoundingBox()
-{
-	D3DXVECTOR3 p(x, y, 0);
-	RECT rect;
-
-	LPTEXTURE bbox = CTextures::GetInstance()->Get(ID_TEX_BBOX);
-
-	float l, t, r, b;
-
-	GetBoundingBox(l, t, r, b);
-	rect.left = 0;
-	rect.top = 0;
-	rect.right = (int)r - (int)l;
-	rect.bottom = (int)b - (int)t;
-
-	float cx, cy;
-	CGame::GetInstance()->GetCamPos(cx, cy);
-
-	float tx;
-	tx = (x - cx);
-	if (level == MARIO_LEVEL_TAIL)
-		tx += (nx < 0) ? -4 : 4;
-	CGame::GetInstance()->Draw(tx, y - cy, bbox, &rect, BBOX_ALPHA);
 }

--- a/05-SceneManager/Mario.cpp
+++ b/05-SceneManager/Mario.cpp
@@ -99,6 +99,8 @@ void CMario::Update(DWORD dt, vector<LPGAMEOBJECT>* coObjects)
 		}
 	}
 
+	HandleRacoonAttack(dt, coObjects);
+
 	CCollision::GetInstance()->Process(this, dt, coObjects);
 	// HandleRacoonAttack(dt, coObjects);
 }
@@ -697,6 +699,15 @@ int CMario::GetAniIdTail()
 	return aniId;
 }
 
+void CMario::HandleRacoonAttack(DWORD dt, vector<LPGAMEOBJECT>* coObjects)
+{
+	if (GetTickCount64() - AttackTime > MARIO_TAIL_ATTACK_TIME && IsAttack) { 
+		CTail* tail = new CTail(x + nx * MARIO_BIG_BBOX_WIDTH, y);
+		CPlayScene::GetInstance()->AddNewObject(tail);
+		IsAttack = false;
+	}
+}
+
 void CMario::Render()
 {
 	CAnimations* animations = CAnimations::GetInstance();
@@ -897,11 +908,7 @@ void CMario::GetBoundingBox(float& left, float& top, float& right, float& bottom
 	}
 }
 
-void CMario::HandleRacoonAttack(DWORD dt, vector<LPGAMEOBJECT>* coObjects)
-{
 	
-}
-
 void CMario::SetLevel(int l)
 {
 	// Adjust position to avoid falling off platform

--- a/05-SceneManager/Mario.h
+++ b/05-SceneManager/Mario.h
@@ -222,7 +222,7 @@ public:
 	{
 		IsAttack = isSitting = false;
 		ax = 0.0f;
-
+		isPiping = false;
 		level = MARIO_LEVEL_BIG;
 		untouchable = 0;
 		untouchable_start = -1;

--- a/05-SceneManager/Mario.h
+++ b/05-SceneManager/Mario.h
@@ -180,7 +180,6 @@ class CMario : public CGameObject
 	int untouchable;
 	ULONGLONG untouchable_start;
 
-	void RenderBoundingBox();
 
 	void OnCollisionWithGoomba(LPCOLLISIONEVENT e);
 	void OnCollisionWithKoopas(LPCOLLISIONEVENT e);

--- a/05-SceneManager/Mario.h
+++ b/05-SceneManager/Mario.h
@@ -205,7 +205,6 @@ public:
 
 	bool render_tail; // Đã vẽ đuôi hay chưa để thoát vòng lặp vẽ đuôi bên playscene
 	BOOLEAN isOnPlatform;
-	CTail* tail;
 
 	bool isHolding = false, pressA = false, canKick = false;
 	bool changeDirection = false;
@@ -230,7 +229,6 @@ public:
 		untouchable_start = -1;
 		isOnPlatform = false;
 		coin = 0;
-		tail = NULL;
 		AttackTime = 0;
 	}
 	void Update(DWORD dt, vector<LPGAMEOBJECT>* coObjects);

--- a/05-SceneManager/PlayScene.cpp
+++ b/05-SceneManager/PlayScene.cpp
@@ -135,7 +135,6 @@ void CPlayScene::_ParseSection_OBJECTS(string line)
 
 	CGameObject* obj = NULL;
 	FallDetector* fallDetector = NULL;
-	CTail* tail = NULL;
 
 	switch (object_type)
 	{
@@ -147,11 +146,6 @@ void CPlayScene::_ParseSection_OBJECTS(string line)
 		obj = new CMario(x, y);
 		player = (CMario*)obj;
 		CMario::SetInstance((CMario*)obj);
-
-		tail = new CTail(x, y);
-		objects.push_back(tail);
-		CMario* tempMario = dynamic_cast<CMario*>(obj);
-		tempMario->tail = tail;
 		DebugOut(L"[INFO] Player object has been created!\n");
 		break;
 	}

--- a/05-SceneManager/SampleKeyEventHandler.cpp
+++ b/05-SceneManager/SampleKeyEventHandler.cpp
@@ -41,7 +41,7 @@ void CSampleKeyHandler::OnKeyDown(int KeyCode)
 		if (CMario::GetInstance()->GetLevel() == MARIO_LEVEL_TAIL) {
 			CMario::GetInstance()->SetState(MARIO_STATE_ATTACK);
 		}
-	break;
+		break;
 	}
 	case DIK_R: // reset
 		//Reload();

--- a/05-SceneManager/SampleKeyEventHandler.cpp
+++ b/05-SceneManager/SampleKeyEventHandler.cpp
@@ -9,7 +9,7 @@
 void CSampleKeyHandler::OnKeyDown(int KeyCode)
 {
 	//DebugOut(L"[INFO] KeyDown: %d\n", KeyCode);
-	CMario* mario = (CMario *)((LPPLAYSCENE)CGame::GetInstance()->GetCurrentScene())->GetPlayer(); 
+	CMario* mario = (CMario*)((LPPLAYSCENE)CGame::GetInstance()->GetCurrentScene())->GetPlayer();
 
 	switch (KeyCode)
 	{
@@ -37,17 +37,12 @@ void CSampleKeyHandler::OnKeyDown(int KeyCode)
 	case DIK_0:
 		mario->SetState(MARIO_STATE_DIE);
 		break;
-	case DIK_A:
-	{
-		DebugOut(L"Down A\n");
-		CMario::GetInstance()->pressA = true;
-		if (CMario::GetInstance()->GetLevel() == MARIO_LEVEL_TAIL)
-		{
+	case DIK_A: {
+		if (CMario::GetInstance()->GetLevel() == MARIO_LEVEL_TAIL) {
 			CMario::GetInstance()->SetState(MARIO_STATE_ATTACK);
 		}
-	}
 	break;
-
+	}
 	case DIK_R: // reset
 		//Reload();
 		break;
@@ -65,8 +60,6 @@ void CSampleKeyHandler::OnKeyUp(int KeyCode)
 	{
 		DebugOut(L"Up A\n");
 		CMario::GetInstance()->pressA = false;
-		/*if (CMario::GetInstance()->isHolding == true)
-			CMario::GetInstance()->isHolding = false;*/
 		if (CMario::GetInstance()->isHolding == true) // đang giữ rùa, thả nút a thì chuyển sang đá
 		{
 			CMario::GetInstance()->canKick = true;
@@ -83,7 +76,7 @@ void CSampleKeyHandler::OnKeyUp(int KeyCode)
 	}
 }
 
-void CSampleKeyHandler::KeyState(BYTE *states)
+void CSampleKeyHandler::KeyState(BYTE* states)
 {
 	LPGAME game = CGame::GetInstance();
 	CMario* mario = (CMario*)((LPPLAYSCENE)CGame::GetInstance()->GetCurrentScene())->GetPlayer();
@@ -102,10 +95,6 @@ void CSampleKeyHandler::KeyState(BYTE *states)
 		else
 			mario->SetState(MARIO_STATE_WALKING_LEFT);
 	}
-	/*else if (game->IsKeyDown(DIK_S))
-	{
-		mario->SetState(MARIO_GIU_NUT_S);
-	}*/
 	else
 		mario->SetState(MARIO_STATE_IDLE);
 }

--- a/05-SceneManager/Tail.h
+++ b/05-SceneManager/Tail.h
@@ -35,8 +35,6 @@ public:
 	};
 	virtual void GetBoundingBox(float& left, float& top, float& right, float& bottom);
 	virtual void Update(DWORD dt, vector<LPGAMEOBJECT>* coObjects = NULL);
-	virtual void OnNoCollision(DWORD dt);
-	virtual void OnCollisionWith(LPCOLLISIONEVENT e);
 	void RenderBoundingBox();
 	void SetState(int state);
 	void OnCollisionWithBreakableBrick(LPGAMEOBJECT& obj);

--- a/05-SceneManager/main.cpp
+++ b/05-SceneManager/main.cpp
@@ -1,16 +1,16 @@
 /* =============================================================
 	INTRODUCTION TO GAME PROGRAMMING SE102
-	
+
 	SAMPLE 05 - SCENE MANAGER
 
 	This sample illustrates how to:
 
-		1/ Read scene (textures, sprites, animations and objects) from files 
+		1/ Read scene (textures, sprites, animations and objects) from files
 		2/ Handle multiple scenes in game
 
 	Key classes/functions:
 		CScene
-		CPlayScene		
+		CPlayScene
 
 
 HOW TO INSTALL Microsoft.DXSDK.D3DX
@@ -77,7 +77,7 @@ void Update(DWORD dt)
 }
 
 /*
-	Render a frame 
+	Render a frame
 */
 void Render()
 {
@@ -135,7 +135,7 @@ HWND CreateGameWindow(HINSTANCE hInstance, int nCmdShow, int ScreenWidth, int Sc
 			hInstance,
 			NULL);
 
-	if (!hWnd) 
+	if (!hWnd)
 	{
 		OutputDebugString(L"[ERROR] CreateWindow failed");
 		DWORD ErrCode = GetLastError();
@@ -175,14 +175,14 @@ int Run()
 		{
 			frameStart = now;
 
-			CGame::GetInstance()->ProcessKeyboard();	
+			CGame::GetInstance()->ProcessKeyboard();
 			Update(dt);
 			Render();
 
-			 CGame::GetInstance()->SwitchScene();
+			CGame::GetInstance()->SwitchScene();
 		}
 		else
-			Sleep(tickPerFrame - dt);	
+			Sleep(tickPerFrame - dt);
 	}
 
 	return 1;
@@ -202,7 +202,7 @@ int WINAPI WinMain(
 	game->Init(hWnd, hInstance);
 	game->InitKeyboard();
 	//IMPORTANT: this is the only place where a hardcoded file name is allowed ! 
-	game->Load(GAME_FILE_TXT);  
+	game->Load(GAME_FILE_TXT);
 	SetWindowPos(hWnd, 0, 50, 150, SCREEN_WIDTH * 2, SCREEN_HEIGHT * 2, SWP_NOZORDER | SWP_SHOWWINDOW);
 	Run();
 


### PR DESCRIPTION
- fix lỗi vừa vào bị crash do `isPiping` mặc định bằng `true`
- xóa thuộc tính `CTail* tail` đi theo mario, thay vào đó add object `tail` mỗi khi mario có state `attacking`, sau attack xóa tail
- fix lỗi bounding box mario tail bị sai => mario đi xuyên gạch nếu đứng đúng bug